### PR TITLE
Fix link in the README

### DIFF
--- a/core/esmf-aspect-meta-model-python/README.md
+++ b/core/esmf-aspect-meta-model-python/README.md
@@ -1,5 +1,5 @@
 The Aspect Model Loader as part of the Python SDK provided by the [*Eclipse Semantic Modeling Framework*](
-https://projects.eclipse.org/projects/dt.esmf]).
+https://projects.eclipse.org/projects/dt.esmf).
 
 # An Aspect of the Meta Model
 


### PR DESCRIPTION
Changes:

Fixed a link to the "Eclipse Semantic Modeling Framework" in the README document.