### PR TITLE
Upgrade SAMM-CLI to v2.13.1 so as to support the `aspect to aas` functionality

### DIFF
--- a/core/esmf-aspect-meta-model-python/README.md
+++ b/core/esmf-aspect-meta-model-python/README.md
@@ -147,7 +147,7 @@ For instance, validation of a model can be done with the following code snippet:
 from esmf_aspect_meta_model_python.samm_cli import SammCli
 
 samm_cli = SammCli()
-model_path = "Paht_to_the_model/Model.ttl"
+model_path = "Path_to_the_model/Model.ttl"
 samm_cli.validate(model_path)
 # Input model is valid
 ```

--- a/core/esmf-aspect-meta-model-python/esmf_aspect_meta_model_python/constants.py
+++ b/core/esmf-aspect-meta-model-python/esmf_aspect_meta_model_python/constants.py
@@ -11,7 +11,7 @@
 
 
 SAMM_VERSION = "2.2.0"
-JAVA_CLI_VERSION = "2.12.0"
+JAVA_CLI_VERSION = "2.13.1"
 
 SAMM_NAMESPACE_PREFIX = "samm"
 SAMM_ORG_IDENTIFIER = "org.eclipse.esmf.samm"

--- a/core/esmf-aspect-meta-model-python/esmf_aspect_meta_model_python/samm_cli/base.py
+++ b/core/esmf-aspect-meta-model-python/esmf_aspect_meta_model_python/samm_cli/base.py
@@ -169,6 +169,8 @@ class SammCli:
             - parameter-file, p: the path to a file including the parameter for the Aspect API endpoints.
                 For detailed description, please have a look at a SAMM CLI documentation (https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html#using-the-cli-to-create-a-json-openapi-specification)  # noqa: E501
             - semantic-version, sv: use the full semantic version from the Aspect Model as the version for the Aspect API
+            - read-api-path, rap: Set the path for the default endpoint (default: /api/vX, where X is the Aspect Model major version)
+            - query-api-path, qap: Set the path for the query endpoint (default: /query-api/vX, where X is the Aspect Model major version)
             - resource-path, r: the resource path for the Aspect API endpoints
                 For detailed description, please have a look at a SAMM CLI documentation (https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html#using-the-cli-to-create-a-json-openapi-specification)  # noqa: E501
             - include-query-api, q: include the path for the Query Aspect API Endpoint in the OpenAPI specification
@@ -177,7 +179,7 @@ class SammCli:
             - paging-offset-based, po: in case there is more than one paging possibility, it must be offset based paging
             - paging-time-based, pt: in case there is more than one paging possibility, it must be time based paging
             - language, l: the language from the model for which an OpenAPI specification should be generated (default: en)
-            custom-resolver: use an external resolver for the resolution of the model elements
+            - custom-resolver: use an external resolver for the resolution of the model elements
         """
         return self._call_function(SAMMCLICommands.TO_OPENAPI, path_to_model, *args, capture=capture, **kwargs)
 
@@ -333,18 +335,17 @@ class SammCli:
         """
         return self._call_function(SAMMCLICommands.TO_SQL, path_to_model, *args, capture=capture, **kwargs)
 
-    # FIXME: https://github.com/eclipse-esmf/esmf-sdk/issues/802
-    # def to_aas(self, path_to_model, *args, capture=False, **kwargs):
-    #     """Generate an Asset Administration Shell (AAS) submodel template from an Aspect Model.
-    #
-    #     param path_to_model: local path to the aspect model file (*.ttl)
-    #     possible arguments:
-    #         - output, o: output file path (default: stdout)
-    #         - format, f: output file format (XML, JSON, or AASX, default: XML)
-    #         - aspect_data, a: path to a JSON file containing aspect data corresponding to the Aspect Model
-    #         - custom_resolver: use an external resolver for the resolution of the model elements
-    #     """
-    #     return self._call_function(SAMMCLICommands.AAS_TO_ASPECT, path_to_model, *args, capture=capture, **kwargs)
+    def to_aas(self, path_to_model, *args, capture=False, **kwargs):
+        """Generate an Asset Administration Shell (AAS) submodel template from an Aspect Model.
+
+        param path_to_model: local path to the aspect model file (*.ttl)
+        possible arguments:
+            - output, o: output file path (default: stdout)
+            - format, f: output file format (XML, JSON, or AASX, default: XML)
+            - aspect_data, a: path to a JSON file containing aspect data corresponding to the Aspect Model
+            - custom_resolver: use an external resolver for the resolution of the model elements
+        """
+        return self._call_function(SAMMCLICommands.TO_AAS, path_to_model, *args, capture=capture, **kwargs)
 
     def edit_move(self, path_to_model, element, namespace=None, *args, capture=False, **kwargs):
         """Move a model element definition from its current place to another existing or

--- a/core/esmf-aspect-meta-model-python/tests/integration/test_cli_functions.py
+++ b/core/esmf-aspect-meta-model-python/tests/integration/test_cli_functions.py
@@ -216,17 +216,16 @@ class TestSammCliIntegration:
             if isinstance(jsonld, dict):  # JSON-LD should have @context or @graph
                 assert "@context" in jsonld or "@graph" in jsonld
 
-    #  FIXME: https://github.com/eclipse-esmf/esmf-sdk/issues/802
-    # def test_to_aas(self, samm_cli, file_path, temp_output_dir):
-    #     """Test generating AAS submodel template."""
-    #     output_file_json = os.path.join(temp_output_dir, "aas.json")
-    #
-    #     samm_cli.to_aas(file_path, output=output_file_json, format="JSON")
-    #
-    #     assert os.path.exists(output_file_json)
-    #     with open(output_file_json, "r") as f:
-    #         aas_json = json.load(f)
-    #         assert isinstance(aas_json, (dict, list))
+    def test_to_aas(self, samm_cli, file_path, temp_output_dir):
+        """Test generating AAS submodel template."""
+        output_file_json = os.path.join(temp_output_dir, "aas.json")
+
+        samm_cli.to_aas(file_path, output=output_file_json, format="JSON")
+
+        assert os.path.exists(output_file_json)
+        with open(output_file_json, "r") as f:
+            aas_json = json.load(f)
+            assert isinstance(aas_json, (dict, list))
 
     def test_package_export_import(self, samm_cli, file_path, temp_output_dir):
         """Test exporting and importing a package."""

--- a/core/esmf-aspect-meta-model-python/tests/unit/samm_cli/test_base.py
+++ b/core/esmf-aspect-meta-model-python/tests/unit/samm_cli/test_base.py
@@ -564,19 +564,18 @@ class TestSammCliFunctions:
             custom_column="col1 STRING",
         )
 
-    # FIXME: https://github.com/eclipse-esmf/esmf-sdk/issues/802
-    # def test_to_aas(self, call_function_mock, samm_cli):
-    #     result = samm_cli.to_aas("path_to_ttl_model", output="aas.aasx", format="aasx", aspect_data="data.json")
-    #
-    #     assert result is call_function_mock.return_value
-    #     call_function_mock.assert_called_once_with(
-    #         SAMMCLICommands.AAS_TO_ASPECT,
-    #         "path_to_ttl_model",
-    #         capture=False,
-    #         output="aas.aasx",
-    #         format="aasx",
-    #         aspect_data="data.json",
-    #     )
+    def test_to_aas(self, call_function_mock, samm_cli):
+        result = samm_cli.to_aas("path_to_ttl_model", output="aas.aasx", format="aasx", aspect_data="data.json")
+
+        assert result is call_function_mock.return_value
+        call_function_mock.assert_called_once_with(
+            SAMMCLICommands.TO_AAS,
+            "path_to_ttl_model",
+            capture=False,
+            output="aas.aasx",
+            format="aasx",
+            aspect_data="data.json",
+        )
 
     @pytest.mark.parametrize(
         "element,namespace,flags,expected_function_name",


### PR DESCRIPTION
## Description

This PR upgrades the SAMM-CLI version to 2.13.1 so that users can use the `aspect to aas` feature through the SammCli class. This fix also includes:

* uncomment the sections related to the `aspect to aas` feature and fix a minor bug
* document the `rap` and `qap` options in the docstring of SammCli's to_openapi function, which are newly supported in v2.13.1
* fix minor typos in the documentation

Fixes #64 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

  - The `to_aas` feature has already been documented in README.md, so additional change wasn't needed

- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
