### PR TITLE
fix(loader): make cyclic reference restoration deterministic

### DIFF
--- a/core/esmf-aspect-meta-model-python/esmf_aspect_meta_model_python/loader/default_element_cache.py
+++ b/core/esmf-aspect-meta-model-python/esmf_aspect_meta_model_python/loader/default_element_cache.py
@@ -141,7 +141,9 @@ class DefaultElementCache(CacheStrategy):
         """Initialize the instance cache, active path, and cycle reference store."""
         self._instance_cache: dict[str, Base] = {}
         self._active_path: set = set()
-        self._cycle_reference_store: set[DeferredReference] = set()
+        # Dict keys keep insertion order (guaranteed since Python 3.7) and deduplicate
+        # via DeferredReference.__hash__/__eq__, giving deterministic restoration order.
+        self._cycle_reference_store: dict[DeferredReference, None] = {}
 
     def add_to_active_path(self, node):
         """Add a node to the active path (for cycle detection during recursion)."""
@@ -157,13 +159,13 @@ class DefaultElementCache(CacheStrategy):
 
     def add_deferred_reference(self, deferred_ref: DeferredReference):
         """Add a DeferredReference to the cycle reference store for later restoration, only if not already present."""
-        self._cycle_reference_store.add(deferred_ref)
+        self._cycle_reference_store[deferred_ref] = None
 
     def restore_cycle_references(self):
         """Restore all deferred cyclic references after object creation.
 
-        Iterates over the cycle reference store and sets the appropriate attributes on parent objects
-        to reference the now-created target objects.
+        Iterates over the cycle reference store in insertion order and sets the appropriate attributes on parent
+        objects to reference the now-created target objects.
         """
         for record in self._cycle_reference_store:
             record.restore(self)

--- a/core/esmf-aspect-meta-model-python/tests/unit/loader/test_default_element_cache.py
+++ b/core/esmf-aspect-meta-model-python/tests/unit/loader/test_default_element_cache.py
@@ -162,7 +162,7 @@ class TestDefaultElementCache:
         assert result is not None
         assert result._instance_cache == {}
         assert result._active_path == set()
-        assert result._cycle_reference_store == set()
+        assert result._cycle_reference_store == {}
 
     def test_add_to_active_path(self):
         """Test add_to_active_path adds a node to the active path set."""
@@ -196,33 +196,33 @@ class TestDefaultElementCache:
         result = cache.add_deferred_reference(deferred_ref)
 
         assert result is None
-        assert cache._cycle_reference_store == {deferred_ref}
+        assert cache._cycle_reference_store == {deferred_ref: None}
 
     def test_restore_cycle_references(self):
         """Test restore_cycle_references calls restore on all DeferredReferences in the store."""
         cache = DefaultElementCache()
         deferred_ref1 = MagicMock(spec=DeferredReference)
         deferred_ref2 = MagicMock(spec=DeferredReference)
-        cache._cycle_reference_store = [deferred_ref1, deferred_ref2]
+        cache._cycle_reference_store = {deferred_ref1: None, deferred_ref2: None}
         result = cache.restore_cycle_references()
 
         assert result is None
         deferred_ref1.restore.assert_called_once_with(cache)
         deferred_ref2.restore.assert_called_once_with(cache)
-        assert cache._cycle_reference_store == []
+        assert cache._cycle_reference_store == {}
 
     def test_reset(self):
         """Test reset clears all caches and sets in DefaultElementCache."""
         cache = DefaultElementCache()
         cache._instance_cache = {"a": MagicMock()}
         cache._active_path = {"node"}
-        cache._cycle_reference_store = [MagicMock()]
+        cache._cycle_reference_store = {MagicMock(): None}
         result = cache.reset()
 
         assert result is None
         assert cache._instance_cache == {}
         assert cache._active_path == set()
-        assert cache._cycle_reference_store == []
+        assert cache._cycle_reference_store == {}
 
     def test_get(self):
         """Test get returns the cached object by URN or None if not found."""


### PR DESCRIPTION
Deferred cyclic references were stored in a set, whose iteration order is undefined. Because restoration appends to list-valued attributes, this made their element order vary between loads of the same model.

Store them in an insertion-ordered dict (ordered-set idiom): dict keys keep insertion order (guaranteed since Python 3.7) and still deduplicate via DeferredReference.__hash__/__eq__, so restoration order is now deterministic. Update affected unit tests to the new container representation.

Refs #70
