### PR TITLE
docs: align READMEs, user guide and metadata with the actual codebase

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,13 +1,7 @@
 # Authors
 
-The following people have contributed to this repository:
+The authoritative list of authors and contributors is maintained as the
+[`[project].authors`](core/esmf-aspect-meta-model-python/pyproject.toml) field in
+`pyproject.toml`, which serves as the single source of truth.
 
-* [Hanna Shalamitskaya](https://github.com/Hanna-Shalamitskaya-EPAM), external.Hanna.Shalamitskaya@de.bosch.com
-* [Oleksandr Muzyka](https://github.com/o-muzyka), external.Oleksandr.Muzyka@bosch.com
-* [Andreas Textor](https://github.com/atextor), Robert Bosch GmbH, andreas.textor@de.bosch.com
-* Georg Schmidt-Dumont, Robert Bosch GmbH, georg.schmidt-dumont@de.bosch.com
-* [Michele Santoro](https://github.com/michelu89), Robert Bosch GmbH, michele.santoro@de.bosch.com
-* Nico Makowe
-* Aghyad Farrouh
-
-Please add yourself to this list, if you contribute to the content.
+If you contribute to this repository, please add yourself there.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,13 +28,17 @@ Records](https://adr.github.io/madr/) in [documentation/decisions/](documentatio
 
 We follow the [Git branching guidance](https://docs.microsoft.com/en-us/azure/devops/repos/git/git-branching-guidance?view=azure-devops).
 
-More specifically the repository has the following branches:
+More specifically the repository uses the following branches:
 
-| name of branch                           | description                                                                                                                                                                                                                                                           |
-|------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `main`                                   | Contains the latest state of the repository                                                                                                                                                                                                                           |
-| `v{version_number}-RC{rc_number}`        | A state on which the working group agreed on as a release candidate but which is missing the approval by the OMP.                                                                                                                                                     |
-| `v{version_number}`                      | A release of the respective version which is approved by the working group and the OMP.                                                                                                                                                                               |
+| name of branch                     | description                                                                                                                                    |
+|------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| `main`                             | Contains the latest state of the repository.                                                                                                   |
+| `<major>.<minor>.x` (e.g. `2.3.x`) | Maintenance branch for a released minor version. It is created automatically by the release workflow; patch releases are cut from this branch. |
+| `<issue-number>-<feature-name>`    | A feature branch (developed in a fork) that references an issue and targets `main` via a pull request. See [Pull Requests](#pull-requests).    |
+
+Released versions are marked with annotated git tags of the form `v<major>.<minor>.<patch>`
+(e.g. `v2.3.0`); pre-releases use a suffix (e.g. `v2.3.0-M1`). See
+[Version Syntax for Specific Environments](#version-syntax-for-specific-environments).
 
 ## Issues
 
@@ -115,19 +119,17 @@ end. Also, all contributions must have the same license as the source. The heade
 following template:
 
 ```
-/*
- * Copyright (c) {YEAR} {NAME OF COMPANY X} 
- * Copyright (c) {YEAR} {NAME OF COMPANY Y} 
- *
- * See the AUTHORS file(s) distributed with this work for additional
- * information regarding authorship.
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/.
- *
- * SPDX-License-Identifier: MPL-2.0
- */
+#  Copyright (c) {YEAR} {NAME OF COMPANY X}
+#  Copyright (c) {YEAR} {NAME OF COMPANY Y}
+#
+#  See the AUTHORS file(s) distributed with this work for additional
+#  information regarding authorship.
+#
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+#  SPDX-License-Identifier: MPL-2.0
 ```
 
 When using the template, one must replace "{NAME OF COMPANY X}" with the name of the involved
@@ -185,7 +187,7 @@ vX.Y.Z-[pre-release-identifier]
 
 Examples:
 
-v1.0.0-RC1, v1.0.0
+v2.3.0-M1, v2.3.0
 
 # Resources
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -19,7 +19,10 @@ The libraries black, flake8 and isort are also used so that the code can be chec
 ## Documentation
 
 ### Developer Documentation
-Developer documentation is put into a README.md placed in the project root. This should contain documentation like:
+Developer documentation is provided in `README.md` files: a top-level `README.md` gives an overview of
+the repository, and each component has its own `README.md` (for example the
+`core/esmf-aspect-meta-model-python` module and its subpackages such as `base`, `impl`, `loader` and
+`resolver`). This documentation should cover topics like:
 * Checking out the source code and getting it to run/build
 * Mandatory (external system) dependencies and how to set them up (e.g. databases)
 * Configuration options and how to apply them

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -2,6 +2,6 @@
 
 This repository contains software developed by the [Antora Project](https://antora.org/).
 
-Your use of Antora is subject to the terms and conditions of the Mozilla Public License 2.0. A copy of the license is contained in the file [LICENSE.txt](/LICENSE.txt) and is also available at https://mozilla.org/MPL/2.0/.
+Your use of Antora is subject to the terms and conditions of the Mozilla Public License 2.0. A copy of the license is contained in the file [LICENSE](/LICENSE) and is also available at https://mozilla.org/MPL/2.0/.
 
 The source code is available from [GitLab](https://gitlab.com/antora).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
     - [esmf-aspect-meta-model-python](#esmf-aspect-meta-model-python)
 - [Version Handling](#version-handling)
     - [SAMM Versioning](#samm-versioning)
-    - [API Versioning](#api-versioning)
 - [About](#about)
     - [Building](#building)
     - [Contributors](#contributors)
@@ -70,16 +69,17 @@ generated source code artifacts. Any form of source code generator will use the 
 
 ## Version Handling
 
-The aspect meta model loader work with the SAMM versions specified in the [download_samm_release.py](core/esmf-aspect-meta-model-python/esmf_aspect_meta_model_python//samm_aspect_meta_model/download_samm_release.py). 
+The aspect meta model loader work with the SAMM versions specified in the [download_samm_release.py](core/esmf-aspect-meta-model-python/scripts/samm/download_samm_release.py). 
 This version will be used for deployment.
 
 As SAMM evolves over time, the Aspect Meta Model Loader should also adapt and evolve accordingly.
 Due to this fact it is important to understand the versioning concept that is applied to the SAMM,
 APIs and SDK components that are derived from them.
 
-In case of a prerelease there will be a postfix added and it will be released under Github.
-The way to access the artifact is described
-in [Github-Installing a package](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry#installing-a-package)
+In case of a prerelease a PEP 440 suffix is added to the version (e.g. `2.3.0rc1`) and the package is
+published to PyPI as a pre-release. Install a specific (pre-)release with
+`pip install esmf-aspect-model-loader==<version>` or `uv add esmf-aspect-model-loader==<version>`.
+Released artifacts are also attached to the corresponding [GitHub release](https://github.com/eclipse-esmf/esmf-sdk-py-aspect-model-loader/releases).
 
 ### SAMM Versioning
 
@@ -121,7 +121,7 @@ order to e.g. build a package or run the tests for a package navigate to the pac
 
 ### Contributors
 
-... and you? Feel free to add [yourself](AUTHORS.md) to this list when issuing your PR!
+... and you? Feel free to add yourself to the [`authors` list in `pyproject.toml`](core/esmf-aspect-meta-model-python/pyproject.toml) when issuing your PR!
 
 ### Contribution Guidelines
 
@@ -146,6 +146,7 @@ introducing too many transitive dependencies downstream.
 | pytest-dev/pytest-cov | MIT License (MIT)                    | Development dependency |
 | pytest-sugar          | BSD License (BSD)                    | Development dependency |
 | tox                   | MIT License (MIT)                    | Development dependency |
+| tox-uv                | MIT License (MIT)                    | Development dependency |
 | types-requests        | Apache Software License (Apache 2.0) | Development dependency |
 
 ### Documentation

--- a/core/esmf-aspect-meta-model-python/README.md
+++ b/core/esmf-aspect-meta-model-python/README.md
@@ -196,6 +196,19 @@ be running with the tox:
 - pep8: static code checks (PEP8 style) with MyPy and Black
 - py310: unit and integration tests
 
+### tox-uv plugin
+
+`tox` is integrated with `uv` through the [`tox-uv`](https://github.com/tox-dev/tox-uv) plugin. Both `tox` and 
+`tox-uv` are declared as `dev` dependencies in [pyproject.toml](pyproject.toml), so a single `uv sync` installs 
+everything required - no separate installation step is needed.
+
+The two environments use the plugin differently (see [tox.ini](tox.ini)):
+- `pep8` uses the `uv-venv-lock-runner` provided by `tox-uv`, which provisions the environment directly from the 
+  pinned `uv.lock` and installs the `dev` dependency group. This guarantees the linters run with the exact, locked 
+  versions.
+- `py310` uses the default runner and explicitly runs `uv sync` and `uv run download-samm-release` in its 
+  `commands_pre` to prepare dependencies and the SAMM meta model files before executing the test suite.
+
 ```console
 # run all checks use the next command
 uv run tox

--- a/core/esmf-aspect-meta-model-python/esmf_aspect_meta_model_python/base/README.md
+++ b/core/esmf-aspect-meta-model-python/esmf_aspect_meta_model_python/base/README.md
@@ -4,47 +4,66 @@ It can be seen as a contract that establishes a fixed structure and inheritance 
 The classes should not be instantiated because they are abstract which is similar to interfaces in Java.
 
 # Inheritance hierarchy
-```
-HasUrn
-├───────────────────────────────────────────────── DataType
-└── IsDescribed                                    ├── Scalar
-    └── Base                    HasProperties      │
-        ├── StructureElement <──┘                  │
-        │   ├── Aspect                             │
-        │   └── ComplexType <──────────────────────┘
-        │       ├── AbstractEntity
-        │       └── Entity
-        ├── Characteristic
-        │   ├── Code
-        │   ├── Collection
-        │   │   ├── List
-        │   │   ├── Set
-        │   │   └── SortedSet
-        │   │       └── TimeSeries
-        │   ├── Either
-        │   ├── Enumeration
-        │   │   └── State
-        │   ├── SingleEntity
-        │   ├── StructuredValue
-        │   ├── Quantifiable
-        │   │   ├── Duration
-        │   │   └── Measurement
-        │   └── Trait
-        ├── Constraint
-        │   ├── EncodingConstraint
-        │   ├── FixedPointConstraint
-        │   ├── LanguageConstraint
-        │   ├── LengthConstraint
-        │   ├── LocaleConstraint
-        │   ├── RangeConstraint
-        │   └── RegularExpressionConstraint
-        ├── Namespace
-        ├── Event
-        ├── Operation
-        ├── Property
-        ├── QuantityKind
-        ├── Unit
-        └── Value
 
-BoundDefiniton
+The diagram below shows the inheritance hierarchy of the base (interface) classes. `HasUrn`,
+`IsDescribed` and `HasProperties` are abstract base classes; `StructureElement` and `ComplexType`
+use multiple inheritance.
+
+```mermaid
+classDiagram
+    HasUrn <|-- IsDescribed
+    HasUrn <|-- DataType
+    IsDescribed <|-- Base
+
+    Base <|-- StructureElement
+    HasProperties <|-- StructureElement
+    StructureElement <|-- Aspect
+    StructureElement <|-- ComplexType
+    DataType <|-- ComplexType
+    DataType <|-- Scalar
+    ComplexType <|-- AbstractEntity
+    ComplexType <|-- Entity
+
+    Base <|-- Characteristic
+    Characteristic <|-- Code
+    Characteristic <|-- Collection
+    Collection <|-- List
+    Collection <|-- Set
+    Collection <|-- SortedSet
+    SortedSet <|-- TimeSeries
+    Characteristic <|-- Enumeration
+    Enumeration <|-- State
+    Characteristic <|-- SingleEntity
+    Characteristic <|-- StructuredValue
+    Characteristic <|-- Quantifiable
+    Quantifiable <|-- Duration
+    Quantifiable <|-- Measurement
+    Characteristic <|-- Trait
+
+    Base <|-- Either
+    Base <|-- Constraint
+    Constraint <|-- EncodingConstraint
+    Constraint <|-- FixedPointConstraint
+    Constraint <|-- LanguageConstraint
+    Constraint <|-- LengthConstraint
+    Constraint <|-- LocaleConstraint
+    Constraint <|-- RangeConstraint
+    Constraint <|-- RegularExpressionConstraint
+
+    Base <|-- Namespace
+    Base <|-- Event
+    Base <|-- Operation
+    Base <|-- AbstractProperty
+    AbstractProperty <|-- Property
+    Base <|-- QuantityKind
+    Base <|-- Unit
+    QuantityKind <|-- Unit
+    Base <|-- Value
+
+    class HasUrn { <<abstract>> }
+    class IsDescribed { <<abstract>> }
+    class HasProperties { <<abstract>> }
 ```
+
+> Note: `BoundDefinition` is a standalone `enum.Enum` (the upper/lower boundary rule for a
+> `RangeConstraint`) and is therefore not part of the class hierarchy above.

--- a/core/esmf-aspect-meta-model-python/esmf_aspect_meta_model_python/impl/README.md
+++ b/core/esmf-aspect-meta-model-python/esmf_aspect_meta_model_python/impl/README.md
@@ -6,53 +6,35 @@ The classes in here are derived from the base folder.
 
 Every Model Class in Default Implementation of the SAMM Aspect Meta Model 
 is derived from the DefaultBase class. 
-It consists of the following attributes:
-```
-BASE ATTRIBUTES
-├── meta_model_version
-├── urn
-├── name
-├── preferred_names
-├── descriptions
-└── see
-```
-An aspect has the following hierarchy:
-```
-Schmematic object structure of an aspect
+The base attributes (referred to as **BASE ATTRIBUTES** below) are:
 
-aspect
-├── BASE ATTRIBUTES
-├── is_collection_aspect
-├── properties
-│   ├──[0]
-│   │   ├── BASE ATTRIBUTES
-│   │   ├── characteristic
-│   │   │   ├── BASE ATTRIBUTES
-│   │   │   ├── data_type
-│   │   │   └── ...
-│   │   ├── example_value
-│   │   ├── optional
-│   │   └── not_in_payload
-│   ├──[1]
-│   │   └── ...
-│   └── ...
-├── operations
-│   ├──[0]   
-│   │   ├── BASE ATTRIBUTES
-│   │   ├── input_properties
-│   │   │   └── ...
-│   │   └── output_properties
-│   │       └── ...
-│   ├──[1]
-│   │   └── ...
-│   └── ...
-└── events
-    ├──[0]   
-    │   ├── BASE ATTRIBUTES
-    ├──[1]
-    │   └── ...
-    └── ...
-```
+- `meta_model_version`
+- `urn`
+- `name`
+- `preferred_names`
+- `descriptions`
+- `see`
+
+An aspect has the following schematic object structure:
+
+- `aspect`
+  - *BASE ATTRIBUTES*
+  - `is_collection_aspect`
+  - `properties` (list), each:
+    - *BASE ATTRIBUTES*
+    - `characteristic`
+      - *BASE ATTRIBUTES*
+      - `data_type`
+      - ...
+    - `example_value`
+    - `optional`
+    - `not_in_payload`
+  - `operations` (list), each:
+    - *BASE ATTRIBUTES*
+    - `input_properties` (list)
+    - `output_properties` (list)
+  - `events` (list), each:
+    - *BASE ATTRIBUTES*
 
 # Property
 An instance of type `Property` has exactly one characteristic and additionally
@@ -72,7 +54,8 @@ characteristic.
 `Collection` is a subclass of `Characteristic`. At the same time it is the base class for
 other collection elements like `List` and `SortedSet`.
 
-A collection has a 
+A collection optionally has an `element_characteristic` that describes the characteristic of the
+elements it contains.
 
 ## Trait
 An instance of `Trait` wraps one instance of `Characteristic` 
@@ -86,41 +69,31 @@ with the given constraints.
 Note that the class `Trait` is a subclass of `Characteristic` to avoid confusion.
 
 The hierarchy of the `Trait` looks like this:
-```
-Schematic object Structure of a Trait
 
-Trait
-├── BASE ATTRIBUTES
-├── constraints
-│   ├──[0]
-│   │   ├── BASE ATTRIBUTES
-│   │   └── ...
-│   ├──[1]
-│   │   └── ...
-│   └── ...
-└── base_characteristic
-```
+- `Trait`
+  - *BASE ATTRIBUTES*
+  - `constraints` (list), each:
+    - *BASE ATTRIBUTES*
+  - `base_characteristic`
+
 ### Example
 If the characteristic is a `Scalar`
 that should only have values between 1 and 10 then the
 hierarchy of the `Trait` could look like this:
-```
-Example structure of a Trait
 
-Trait
-├── BASE ATTRIBUTES
-├── constraints
-│   └──[0]: RangeConstraint
-│       ├── BASE ATTRIBUTES
-│       ├── min_value = 1
-│       └── max_value = 10
-└── base_characteristic: Characteristic
-    └── data_type: Scalar
-        └── urn = xsd:Integer
-```
+- `Trait`
+  - *BASE ATTRIBUTES*
+  - `constraints` (list):
+    - `[0]` `RangeConstraint`
+      - *BASE ATTRIBUTES*
+      - `min_value = 1`
+      - `max_value = 10`
+  - `base_characteristic`: `Characteristic`
+    - `data_type`: `Scalar`
+      - `urn = xsd:Integer`
 
 # DataType
-A DataType represents some value. It can be represened by a simple `Scalar` or by
+A DataType represents some value. It can be represented by a simple `Scalar` or by
 a `ComplexType`. Complex types can either be of type `Entity` or `AbstractEntity`.
 
 `Entities` and `AbstractEntities` have a number of properties and can extend other entities.

--- a/core/esmf-aspect-meta-model-python/esmf_aspect_meta_model_python/loader/README.md
+++ b/core/esmf-aspect-meta-model-python/esmf_aspect_meta_model_python/loader/README.md
@@ -4,7 +4,7 @@ of an aspects by a turtle file.
 
 The instantiator folder contains a number of instantiators that handle the instantiation of model elements.
 Each instantiator is responsible for exactly one type of model element.
-Additionally, there are the classes `AspectLoader`, `Instantiator`, `ModelElementFactory` and `MetaModelBaseAttributes`.
+Additionally, there are the classes `SAMMGraph`, `Instantiator`, `ModelElementFactory` and `MetaModelBaseAttributes`.
 
 # MetaModelBaseAttributes
 A wrapper class that holds all attributes of the class `DefaultBase`. It is used as
@@ -22,12 +22,13 @@ BaseAttributes
 An instance of `MetaModelBaseAttributes` is created with the static method `MetaModelBaseAttributes.from_meta_model_element(element_node)` 
 which extracts the attributes from a given node of the aspect graph.
 
-# AspectLoader
-The AspectLoader is the entry point for the instantiation.
-To instantiate a turtle call the static method `AspectLoader.load_aspect_model(file_path)` 
-where `file_path` is the path to the .ttl-file.
+# SAMMGraph
+The `SAMMGraph` is the entry point for the instantiation.
+First parse a Turtle file with `samm_graph.parse(file_path)` (where `file_path` is the path to the
+`.ttl` file), then call `samm_graph.load_aspect_model()` to instantiate the root Aspect, or
+`samm_graph.load_model_elements()` to instantiate all elements of the graph.
 
-The AspectLoader creates an instance of the ModelElementFactory which
+The `SAMMGraph` creates an instance of the `ModelElementFactory` which
 then creates an aspect instance with all of its children.
 
 # Abstract _Instantiator[T]_

--- a/core/esmf-aspect-meta-model-python/esmf_aspect_meta_model_python/resolver/README.md
+++ b/core/esmf-aspect-meta-model-python/esmf_aspect_meta_model_python/resolver/README.md
@@ -11,18 +11,18 @@ The meta model elements are defined in the `samm-aspect-meta-model` folder which
     samm:properties (myProperty) ;
 
 :myProperty a samm:Property ;
-    samm:charactersitic myCharacteristic .
+    samm:characteristic myCharacteristic .
 
 ...
 ```
 
 # Resolvers
 
-When the `AspectLoader` loads an aspect model from a `turtle.ttl`, it generates an RDF graph.
+When the `SAMMGraph` loads an aspect model from a `turtle.ttl`, it generates an RDF graph.
 This graph only contains the nodes defined in the `turtle.ttl` and not the nodes neither from the SAMM turtles 
 nor model namespace links.
 
-Afterwords, the `AspectLoader` can load the aspect model.
+Afterwards, the `SAMMGraph` can load the aspect model.
 
 The task of the `Resolver(s)` is to:
 - load the nodes from the SAMM turtles into the rdf graph;
@@ -46,7 +46,7 @@ Meta model resolver is an interface for the classes to load a SAMM definition fi
 
 ### Namespace resolver 
 
-This resolver is implemented a logic for loading model spreaded across several files (in one namespace) and namespaces.
+This resolver implements the logic for loading a model spread across several files (in one namespace) and namespaces.
 
 | *Class name*            | *Interface*           | Note            |
 |-------------------------|-----------------------|-----------------|

--- a/core/esmf-aspect-meta-model-python/pyproject.toml
+++ b/core/esmf-aspect-meta-model-python/pyproject.toml
@@ -5,8 +5,10 @@ description = "Load Aspect Models based on the Semantic Aspect Meta Model"
 authors = [
     { name = "Eclipse Semantic Modeling Framework" },
     { name = "Hanna Shalamitskaya", email = "external.Hanna.Shalamitskaya@de.bosch.com" },
+    { name = "Oleksandr Muzyka", email = "external.Oleksandr.Muzyka@bosch.com" },
     { name = "Andreas Textor", email = "Andreas.Textor@de.bosch.com" },
     { name = "Georg Schmidt-Dumont", email = "Georg.Schmidt-Dumont@de.bosch.com" },
+    { name = "Michele Santoro", email = "michele.santoro@de.bosch.com" },
     { name = "Nico Makowe" },
     { name = "Aghyad Farrouh" },
     { name = "Lars Heppler", email = "Lars.Heppler@de.bosch.com" },
@@ -28,7 +30,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://projects.eclipse.org/projects/dt.esmf"
-Repository = "https://github.com/bci-oss/esmf-sdk-py-aspect-model-loader"
+Repository = "https://github.com/eclipse-esmf/esmf-sdk-py-aspect-model-loader"
 Documentation = "https://eclipse-esmf.github.io/python-sdk-guide/index.html"
 
 [project.scripts]

--- a/documentation/python-sdk-guide/modules/ROOT/pages/index.adoc
+++ b/documentation/python-sdk-guide/modules/ROOT/pages/index.adoc
@@ -53,7 +53,7 @@ uv --version
 
 Aspect Models are stored as RDF Graphs in `.ttl` (RDF Turtle) files.
 The Aspect Model Loader for Python offers a SAMMGraph class that provides two main methods: `load_aspect_model` and `load_model_elements`.
-Theese methods allows to read a Turtle file and parses the Aspect Model and return either a root Aspect node or a list of all elements from the Aspect Model.
+These methods allow you to read a Turtle file, parse the Aspect Model and return either a root Aspect node or a list of all elements from the Aspect Model.
 The Aspect has references to all of its children (e.g., Properties and Operations).
 
 === Installation
@@ -72,10 +72,12 @@ pip install esmf-aspect-model-loader
 
 You can specify the version of the package by adding the version number after the package name.
 For example, to install a specific version of the package, you can use the following command:
-[source,bash,subs=attributes+]
+[source,bash]
 ----
-pip install esmf-aspect-model-loader=={esmf-sdk-py-aspect-model-loader-version}
+pip install esmf-aspect-model-loader==<version>
 ----
+Replace `<version>` with the desired release; the available versions are listed on
+https://pypi.org/project/esmf-aspect-model-loader/[PyPI].
 
 For more detailed information how to install a library with pip please read
 https://pip.pypa.io/en/stable/user_guide/#installing-packages[pip Installing Packages guide].
@@ -90,10 +92,12 @@ uv add esmf-aspect-model-loader
 
 You can specify the version of the package by adding the version number after the package name.
 For example, to install a specific version of the package, you can use the following command:
-[source,bash,subs=attributes+]
+[source,bash]
 ----
-uv add esmf-aspect-model-loader=={esmf-sdk-py-aspect-model-loader-version}
+uv add esmf-aspect-model-loader==<version>
 ----
+Replace `<version>` with the desired release; the available versions are listed on
+https://pypi.org/project/esmf-aspect-model-loader/[PyPI].
 
 For more detailed information how to add a library via uv please read https://docs.astral.sh/uv/concepts/projects/dependencies/[uv dependencies guide].
 
@@ -137,7 +141,7 @@ Both, relative paths and absolute paths are allowed.
 
 === Traversing the Aspect Model
 
-The attributes of an Aspect can be accessed with like this:
+The attributes of an Aspect can be accessed like this:
 
 [source,python]
 ----
@@ -153,10 +157,10 @@ operations = aspect.operations
 events = aspect.events
 ----
 
-=== Implementation of the OpenAPI specification
+=== Consuming an Aspect via its JSON payload
 
-The Aspect Models Editor provides easy ways to generate an example for an interface via Export JSON functions.
-Based on its structure, you can prepare either a server to send data, or a client to receive via the API.
+The Aspect Model Editor can export an example JSON payload for an Aspect via its _Export JSON_ function.
+For the Movement Aspect the payload looks as follows:
 
 [source,json]
 ----
@@ -172,66 +176,25 @@ Based on its structure, you can prepare either a server to send data, or a clien
 }
 ----
 
-==== A simple example of the server
-[source,python]
-----
-import random
-
-
-def generate_random_float():
-    """Generate a random float value."""
-    return round(random.random(), random.randint(0, 5))
-
-def send_movement_value():
-    """A simple snippet to generate Movement data."""
-    traffic_lights = ["green", "yellow", "red"]
-    movement = {
-        "isMoving": "true" if random.randint(0, 1) else "false",
-        "position": {
-            "altitude": generate_random_float(),
-            "latitude": generate_random_float(),
-            "longitude": generate_random_float()
-        },
-        "speed": generate_random_float(),
-        "speedLimitWarning": traffic_lights[random.randint(0, len(traffic_lights) - 1)]
-    }
-
-    return movement
-----
-
-==== Consumer Example
-[source,python]
-----
-import json
-import requests
-
-def get_movement(url, method="get"):
-    """Get a movement."""
-    response = requests.request(method, url)
-
-    if response.status_code != 200:
-        raise Exception(response.text)
-    else:
-        movement = json.loads(response.text)
-
-        return movement
-----
-
-==== Example of the class for Movement Aspect Model
+The example below shows how to load the Aspect Model with the Aspect Model Loader and expose the
+payload values through a small wrapper class.
 
 [source,python]
 ----
 import json
 import requests
 
-from esmf_aspect_meta_model_python.loader.aspect_loader import AspectLoader
+from esmf_aspect_meta_model_python import SAMMGraph
 
-loader = AspectLoader()
 
 class MovementAspect:
     def __init__(self, path_to_turtle_file):
         self._ttl_file_path = path_to_turtle_file
-        self._aspect = loader.load_aspect_model(self._ttl_file_path)
+
+        # Parse the Turtle file and load the Aspect model.
+        samm_graph = SAMMGraph()
+        samm_graph.parse(self._ttl_file_path)
+        self._aspect = samm_graph.load_aspect_model()
         self._movement = None
 
         self.name = None


### PR DESCRIPTION
Documentation-only overhaul that brings the READMEs, the AsciiDoc user
guide, and project metadata back in line with the actual codebase and
tooling. No production code is changed.

- **README / tooling**: document the `tox-uv` plugin and the uv/tox
  integration, add `tox-uv` to the 3rd-party license table, fix the
  stale `download_samm_release.py` path, and drop the dead
  "API Versioning" TOC anchor.
- **API**: replace the non-existent `AspectLoader` / `aspect_loader`
  references in the user guide and submodule READMEs with the real
  `SAMMGraph` entry point (`parse()` then
  `load_aspect_model()` / `load_model_elements()`), and rewrite the
  Movement example accordingly.
- **Versioning**: use PyPI / PEP 440 (instead of Maven) and an
  explicit `<version>` placeholder pointing to PyPI, keeping
  pyproject/PyPI as the single source of truth; fix the broken LICENSE
  link in `NOTICE.md`.
- **Metadata**: fix the repository URL to the eclipse-esmf upstream,
  complete the `pyproject` `[project].authors` list, reduce
  `AUTHORS.md` to a pointer to `pyproject.toml`, and replace the
  Java-style license-header example in `CONTRIBUTING` with the Python
  (`#`) form.
- **Diagrams**: replace the ASCII inheritance tree in `base/README`
  with an accurate Mermaid class diagram and convert the `impl/README`
  object boxes to maintainable nested lists.
- **Branching / structure**: replace the stale RC/OMP branch
  table with the actual scheme (`main`, `X.Y.x` maintenance branches,
  issue-number feature branches, `vX.Y.Z` tags) and document that
  developer docs live in per-component `README.md` files.
- Fix assorted typos and an incomplete sentence across the touched docs.


## Type of change

- [x] Documentation update (no functional/code changes)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
