### PR TITLE
chore: set development version to 2.3.0.dev0

### DIFF
--- a/core/esmf-aspect-meta-model-python/pyproject.toml
+++ b/core/esmf-aspect-meta-model-python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "esmf-aspect-model-loader"
-version = "2.3.0"
+version = "2.3.0.dev0"
 description = "Load Aspect Models based on the Semantic Aspect Meta Model"
 authors = [
     { name = "Eclipse Semantic Modeling Framework" },

--- a/core/esmf-aspect-meta-model-python/uv.lock
+++ b/core/esmf-aspect-meta-model-python/uv.lock
@@ -309,7 +309,7 @@ wheels = [
 
 [[package]]
 name = "esmf-aspect-model-loader"
-version = "2.3.0"
+version = "2.3.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "rdflib" },


### PR DESCRIPTION
Aligns main with the '.dev0' development-version pattern introduced by the release workflow so the 2.3.0 release passes the version-increment check (2.3.0 > 2.3.0.dev0).