### PR TITLE
Add the `aspect to parquet` support to SammCli

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ introducing too many transitive dependencies downstream.
 | psf/black             | MIT License (MIT)                    | Development dependency |
 | nedbat/coverage       | Apache Software License (Apache 2.0) | Development dependency |
 | isort                 | MIT License (MIT)                    | Development dependency |
+| polars                | MIT License (MIT)                    | Development dependency |
 | python/mypy           | MIT License (MIT)                    | Development dependency |
 | pytest                | MIT License (MIT)                    | Development dependency |
 | pytest-dev/pytest-cov | MIT License (MIT)                    | Development dependency |

--- a/core/esmf-aspect-meta-model-python/esmf_aspect_meta_model_python/samm_cli/base.py
+++ b/core/esmf-aspect-meta-model-python/esmf_aspect_meta_model_python/samm_cli/base.py
@@ -204,6 +204,16 @@ class SammCli:
         """
         return self._call_function(SAMMCLICommands.TO_JSON, path_to_model, *args, capture=capture, **kwargs)
 
+    def to_parquet(self, path_to_model, *args, capture=False, **kwargs):
+        """Generate example Parquet payload data for an Aspect Model.
+
+        param path_to_model: local path to the aspect model file (*.ttl)
+        possible arguments:
+            - output, -o: output file path (default: stdout)
+            - custom-resolver: use an external resolver for the resolution of the model elements
+        """
+        return self._call_function(SAMMCLICommands.TO_PARQUET, path_to_model, *args, capture=capture, **kwargs)
+
     def to_html(self, path_to_model, *args, capture=False, **kwargs):
         """Generate HTML documentation for an Aspect Model.
 

--- a/core/esmf-aspect-meta-model-python/esmf_aspect_meta_model_python/samm_cli/constants.py
+++ b/core/esmf-aspect-meta-model-python/esmf_aspect_meta_model_python/samm_cli/constants.py
@@ -33,6 +33,7 @@ class SAMMCLICommands:
     TO_OPENAPI = "to openapi"
     TO_SCHEMA = "to schema"
     TO_JSON = "to json"
+    TO_PARQUET = "to parquet"
     TO_HTML = "to html"
     TO_PNG = "to png"
     TO_SVG = "to svg"

--- a/core/esmf-aspect-meta-model-python/pyproject.toml
+++ b/core/esmf-aspect-meta-model-python/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
     "types-requests==2.33.0.20260518",
     "tox==4.54.0",
     "tox-uv==1.35.2",
+    "polars>=1.42.1",
 ]
 
 # Pin the uv version that may operate on this project so the lockfile cannot

--- a/core/esmf-aspect-meta-model-python/pyproject.toml
+++ b/core/esmf-aspect-meta-model-python/pyproject.toml
@@ -48,13 +48,13 @@ dev = [
     "flake8==6.1.0",
     "isort==5.13.2",
     "mypy==1.20.2",
+    "polars==1.42.1",
     "pytest==7.4.4",
     "pytest-cov==4.1.0",
     "pytest-sugar==0.9.7",
     "types-requests==2.33.0.20260518",
     "tox==4.54.0",
     "tox-uv==1.35.2",
-    "polars>=1.42.1",
 ]
 
 # Pin the uv version that may operate on this project so the lockfile cannot

--- a/core/esmf-aspect-meta-model-python/tests/integration/test_cli_functions.py
+++ b/core/esmf-aspect-meta-model-python/tests/integration/test_cli_functions.py
@@ -17,6 +17,7 @@ import tempfile
 
 from pathlib import Path
 
+import polars as pl
 import pytest
 
 from esmf_aspect_meta_model_python.samm_cli.base import SammCli
@@ -87,6 +88,18 @@ class TestSammCliIntegration:
             assert isinstance(data, dict)
             assert "testProperty" in data
             assert "testComplexProperty" in data
+
+    def test_to_parquet(self, samm_cli, file_path, temp_output_dir):
+        """Test generating example Parquet payload."""
+        output_file = os.path.join(temp_output_dir, "example.parquet")
+
+        samm_cli.to_parquet(file_path, output=output_file)
+
+        assert os.path.exists(output_file)
+        df = pl.read_parquet(output_file)
+        assert "testProperty" in df.columns
+        assert "testComplexProperty__entityProperty1" in df.columns
+        assert "testComplexProperty__entityProperty2" in df.columns
 
     def test_to_schema(self, samm_cli, file_path, temp_output_dir):
         """Test generating JSON schema."""

--- a/core/esmf-aspect-meta-model-python/tests/unit/samm_cli/test_base.py
+++ b/core/esmf-aspect-meta-model-python/tests/unit/samm_cli/test_base.py
@@ -476,6 +476,14 @@ class TestSammCliFunctions:
             SAMMCLICommands.TO_JSON, "path_to_ttl_model", "flag", capture=False, arg_key="value"
         )
 
+    def test_to_parquet(self, call_function_mock, samm_cli):
+        result = samm_cli.to_parquet("path_to_ttl_model", "flag", arg_key="value")
+
+        assert result is call_function_mock.return_value
+        call_function_mock.assert_called_once_with(
+            SAMMCLICommands.TO_PARQUET, "path_to_ttl_model", "flag", capture=False, arg_key="value"
+        )
+
     def test_to_html(self, call_function_mock, samm_cli):
         result = samm_cli.to_html("path_to_ttl_model", "flag", arg_key="value")
 

--- a/core/esmf-aspect-meta-model-python/uv.lock
+++ b/core/esmf-aspect-meta-model-python/uv.lock
@@ -323,6 +323,7 @@ dev = [
     { name = "flake8" },
     { name = "isort" },
     { name = "mypy" },
+    { name = "polars" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-sugar" },
@@ -344,6 +345,7 @@ dev = [
     { name = "flake8", specifier = "==6.1.0" },
     { name = "isort", specifier = "==5.13.2" },
     { name = "mypy", specifier = "==1.20.2" },
+    { name = "polars", specifier = ">=1.42.1" },
     { name = "pytest", specifier = "==7.4.4" },
     { name = "pytest-cov", specifier = "==4.1.0" },
     { name = "pytest-sugar", specifier = "==0.9.7" },
@@ -618,6 +620,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "polars"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/99/fe77f10a13a778705ef05b499fc708c9a0b0a3680d9eb6bc6e1b6a6b9914/polars-1.42.1.tar.gz", hash = "sha256:2fe94f3059334650bd850ae19a9c165dcd5d9cb12cd95ea04de2201662e70e8a", size = 741532, upload-time = "2026-06-30T04:57:51.504Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/6a/edd939cc6fa04b6415aaa9bf19720fc74ead81234b3d38542e0005816d4d/polars-1.42.1-py3-none-any.whl", hash = "sha256:3c0c65cdfa21a621650c4bdcbbccf93964d052fd766c3e70e84a55d961c259fd", size = 837622, upload-time = "2026-06-30T04:56:34.686Z" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/59/15bcc4dac380c6d63efa5446d8317f22671cbd6c9dadd576bd17a334c45a/polars_runtime_32-1.42.1.tar.gz", hash = "sha256:4d4809e1c1b9a6611f6944f27b24abea902b5159e6b6fa262fd716e947af5afd", size = 3045460, upload-time = "2026-06-30T04:57:52.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/29/16ff6e4e91d71e530d3581f45e342a9cc35072ac6b31dcbc2fa33de2569e/polars_runtime_32-1.42.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:bbdc26d68ee5b23b0ce227fa0599220aa35b77c826b6b0a6b2d8e7f6c1c36974", size = 53117325, upload-time = "2026-06-30T04:56:37.972Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8e/4f8296fcfd1347f1351342fecf13bf2430d7efbae2f1f45964ec7930a99e/polars_runtime_32-1.42.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:f6c0288be940b607dc4a7476c01e67fb6bbee93f5f1dd42c64970274c71008ba", size = 47446251, upload-time = "2026-06-30T04:56:41.459Z" },
+    { url = "https://files.pythonhosted.org/packages/88/2e/0d66a7deadc453b890c3391034ca8ab4b05d0beaebbb92a7d65199fba61b/polars_runtime_32-1.42.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:635d9dbcae2302ae223afb395d5cd220bffa61a53d0ab6871d17c8bc830101cf", size = 51359402, upload-time = "2026-06-30T04:56:44.595Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/10/ffb85fa380bc9c9000dc35f40f44954dde49023018501c54faab94b3a39e/polars_runtime_32-1.42.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d059e8e53cc114ff82f9bd791fd341dc53534a2c745e6f6aa37594c3a93f01fe", size = 57302723, upload-time = "2026-06-30T04:56:47.609Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/63/ca50adc62e44224ca5c622a842ba6f35ee87d1d40ef0df7ea2ed6c6edb08/polars_runtime_32-1.42.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f91f0b13588324905682809d270e1de5f1990c908721c8527657d77a044c9919", size = 51515673, upload-time = "2026-06-30T04:56:50.88Z" },
+    { url = "https://files.pythonhosted.org/packages/63/c3/08fbbf38deaa17bf34a601d327cb7451074098673c78b7c1a8538dde9794/polars_runtime_32-1.42.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b8bf972d99d48aaaa2582e2bce966a6f43bc815bd8725d15f5cab9e2fb15d17", size = 55217259, upload-time = "2026-06-30T04:56:53.834Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/0e/51db89361668fe077a835fc579277f824ba526e7daf7b94d23d25439e0d0/polars_runtime_32-1.42.1-cp310-abi3-win_amd64.whl", hash = "sha256:e9364c26da389a8b7339e4d29e20a3d12af730247e6ed3b7804bddce2477f428", size = 52715432, upload-time = "2026-06-30T04:56:57.109Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c5/2fb8592d691bd114de25d9c84300b23541dca7060eac11d7b4bed0327786/polars_runtime_32-1.42.1-cp310-abi3-win_arm64.whl", hash = "sha256:7051226e6b42ffc395a7a9190377cd28649fbfb991b8f85c6271f4e1cfb736fb", size = 46718300, upload-time = "2026-06-30T04:56:59.855Z" },
 ]
 
 [[package]]

--- a/core/esmf-aspect-meta-model-python/uv.lock
+++ b/core/esmf-aspect-meta-model-python/uv.lock
@@ -345,7 +345,7 @@ dev = [
     { name = "flake8", specifier = "==6.1.0" },
     { name = "isort", specifier = "==5.13.2" },
     { name = "mypy", specifier = "==1.20.2" },
-    { name = "polars", specifier = ">=1.42.1" },
+    { name = "polars", specifier = "==1.42.1" },
     { name = "pytest", specifier = "==7.4.4" },
     { name = "pytest-cov", specifier = "==4.1.0" },
     { name = "pytest-sugar", specifier = "==0.9.7" },


### PR DESCRIPTION
## Description

This PR adds the `to_parquet` function to the `SammCli` class aligning with the SAMM-CLI upgrade to v2.15.1.

Fixes #76 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

  - No corresponding documentation

- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
